### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,5 +38,9 @@
       "import": "./dist/my-lib.es.js"
     },
     "./dist/style.css": "./dist/style.css"
-  }
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/wuruoyun/vue-component-lib-starter.git"
+  },
 }


### PR DESCRIPTION
通常都会使用这个模板发npm包，但是发版之后却发现，在npm包里找不到通往GitHub仓库的链接，所以在这里加上。

使用本模板的用户需要在npm publish的时候改成自己的仓库。